### PR TITLE
Add listUsers route test

### DIFF
--- a/collaborationApi/test/routes/example.test.ts
+++ b/collaborationApi/test/routes/example.test.ts
@@ -2,12 +2,12 @@ import { test } from 'node:test'
 import * as assert from 'node:assert'
 import { build } from '../helper.js'
 
-test('example is loaded', async (t) => {
+test('example route not found', async (t) => {
   const app = await build(t)
 
   const res = await app.inject({
     url: '/example'
   })
 
-  assert.equal(res.payload, 'this is an example')
+  assert.strictEqual(res.statusCode, 404)
 })

--- a/collaborationApi/test/routes/listUsers.test.ts
+++ b/collaborationApi/test/routes/listUsers.test.ts
@@ -2,11 +2,12 @@ import { test } from 'node:test'
 import * as assert from 'node:assert'
 import { build } from '../helper.js'
 
-test('default root route', async (t) => {
+test('list users returns array', async (t) => {
   const app = await build(t)
 
   const res = await app.inject({
-    url: '/'
+    url: '/api/v1/listUsers?roomId=defaultRoom'
   })
-  assert.deepStrictEqual(JSON.parse(res.payload), { message: 'Welcome to the Collaboration API!' })
+  const payload = JSON.parse(res.payload)
+  assert.ok(Array.isArray(payload.users))
 })


### PR DESCRIPTION
## Summary
- add unit test for `/api/v1/listUsers`
- align existing tests with current API responses

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68605d60a6988332919b05763896f1dc