### PR TITLE
Add CreateNodeHandler

### DIFF
--- a/backend/src/handlers/CreateNodeHandler.ts
+++ b/backend/src/handlers/CreateNodeHandler.ts
@@ -1,0 +1,43 @@
+import { WebSocket } from "ws";
+import crypto from "node:crypto";
+import { BaseHandler } from "./BaseHandler.js";
+import StateManagerService from "../services/StateManagerService.js";
+import { MessagePayload } from "../types/payload.js";
+import { CreateNodePayload } from "../types/createNodePayload.js";
+import { MindMapNode } from "../types/state.js";
+
+export class CreateNodeHandler extends BaseHandler {
+  constructor(private stateManager: StateManagerService) {
+    super();
+  }
+
+  handle(socket: WebSocket, message: MessagePayload): void {
+    const { roomId, text, position, color } = message as CreateNodePayload;
+
+    if (!roomId || !text || !position) {
+      socket.send(
+        JSON.stringify({ error: "roomId, text and position are required" }),
+      );
+      return;
+    }
+
+    const newNode: MindMapNode = {
+      id: crypto.randomUUID(),
+      text,
+      position,
+      ...(color ? { color } : {}),
+    };
+
+    this.stateManager.setNode(roomId, newNode);
+
+    const payload = JSON.stringify({ type: "NODE_CREATED", payload: newNode });
+
+    const server = (socket as any).server;
+    server.clients.forEach((client: WebSocket) => {
+      const clientRoomId = (client as any).roomId;
+      if (client.readyState === WebSocket.OPEN && clientRoomId === roomId) {
+        client.send(payload);
+      }
+    });
+  }
+}

--- a/backend/src/handlers/JoinHandler.ts
+++ b/backend/src/handlers/JoinHandler.ts
@@ -1,8 +1,8 @@
-import { WebSocket } from 'ws'; // Explicitly import WebSocket from 'ws'
+import { WebSocket } from "ws"; // Explicitly import WebSocket from 'ws'
 import { BaseHandler } from "./BaseHandler.js";
-import { MessagePayload } from '../types/payload.js';
-import { UserJoinPayload } from '../types/userJoinPayload.js';
-import StateManagerService from '../services/StateManagerService.js';
+import { MessagePayload } from "../types/payload.js";
+import { UserJoinPayload } from "../types/userJoinPayload.js";
+import StateManagerService from "../services/StateManagerService.js";
 
 export class JoinHandler extends BaseHandler {
   constructor(private stateManager: StateManagerService) {
@@ -13,13 +13,24 @@ export class JoinHandler extends BaseHandler {
     const { roomId, userId, userName } = message as UserJoinPayload;
 
     if (!userId || !roomId) {
-      socket.send(JSON.stringify({ error: 'Room ID and User ID are required' }));
+      socket.send(
+        JSON.stringify({ error: "Room ID and User ID are required" }),
+      );
       return;
     }
 
     // Here you would typically add the user to the room in your application logic
     const assignedRoomId = this.stateManager.joinRoom(roomId, userId, userName);
 
-    socket.send(JSON.stringify({ success: true, message: `User ${userId} joined room ${assignedRoomId}` }));
+    // Attach room information to the socket for later broadcasts
+    (socket as any).roomId = assignedRoomId;
+    (socket as any).userId = userId;
+
+    socket.send(
+      JSON.stringify({
+        success: true,
+        message: `User ${userId} joined room ${assignedRoomId}`,
+      }),
+    );
   }
 }

--- a/backend/src/handlers/index.ts
+++ b/backend/src/handlers/index.ts
@@ -2,8 +2,16 @@ import { ServiceContainer } from "../plugins/services.js";
 import { BaseHandler } from "./BaseHandler.js";
 import { JoinHandler } from "./JoinHandler.js";
 import { LeaveHandler } from "./LeaveHandler.js";
+import { CreateNodeHandler } from "./CreateNodeHandler.js";
 
-export const messageHandlers: Record<string, (services: ServiceContainer) => BaseHandler> = {
-  'USER_JOIN': (services: ServiceContainer) => new JoinHandler(services.stateManagerService),
-  'USER_LEFT': (services: ServiceContainer) => new LeaveHandler(services.stateManagerService),
+export const messageHandlers: Record<
+  string,
+  (services: ServiceContainer) => BaseHandler
+> = {
+  USER_JOIN: (services: ServiceContainer) =>
+    new JoinHandler(services.stateManagerService),
+  USER_LEFT: (services: ServiceContainer) =>
+    new LeaveHandler(services.stateManagerService),
+  CREATE_NODE: (services: ServiceContainer) =>
+    new CreateNodeHandler(services.stateManagerService),
 };

--- a/backend/src/types/createNodePayload.ts
+++ b/backend/src/types/createNodePayload.ts
@@ -1,0 +1,6 @@
+export type CreateNodePayload = {
+  roomId: string;
+  text: string;
+  position: { x: number; y: number };
+  color?: string;
+};

--- a/backend/src/types/payload.ts
+++ b/backend/src/types/payload.ts
@@ -1,9 +1,13 @@
 import { UserJoinPayload } from "./userJoinPayload.js";
 import { UserLeftPayload } from "./userLeftPayload.js";
+import { CreateNodePayload } from "./createNodePayload.js";
 
 export type Payload = {
   type: string;
   payload: MessagePayload;
 };
 
-export type MessagePayload = UserJoinPayload | UserLeftPayload;
+export type MessagePayload =
+  | UserJoinPayload
+  | UserLeftPayload
+  | CreateNodePayload;

--- a/backend/test/handlers/createNodeHandler.test.ts
+++ b/backend/test/handlers/createNodeHandler.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { CreateNodeHandler } from '../../src/handlers/CreateNodeHandler.js';
+import StateManagerService from '../../src/services/StateManagerService.js';
+import { WebSocket } from 'ws';
+
+class MockServer {
+  clients: Set<MockSocket> = new Set();
+}
+
+class MockSocket {
+  messages: string[] = [];
+  readyState = WebSocket.OPEN;
+  constructor(public server: MockServer, public roomId: string) {
+    server.clients.add(this);
+  }
+  send(data: string) {
+    this.messages.push(data);
+  }
+}
+
+test('CreateNodeHandler stores node and broadcasts to room', () => {
+  const stateManager = new StateManagerService();
+  const handler = new CreateNodeHandler(stateManager);
+  const server = new MockServer();
+  const socketA = new MockSocket(server, 'room1');
+  const socketB = new MockSocket(server, 'room1');
+
+  // ensure room exists
+  stateManager.joinRoom('room1', 'a', 'A');
+
+  handler.handle(socketA as unknown as WebSocket, {
+    roomId: 'room1',
+    text: 'hello',
+    position: { x: 0, y: 0 },
+  } as any);
+
+  const room = stateManager.getRoom('room1');
+  assert.ok(room);
+  assert.equal(room!.mindMap.nodes.size, 1);
+
+  assert.equal(socketA.messages.length, 1);
+  assert.equal(socketB.messages.length, 1);
+  const msg = JSON.parse(socketA.messages[0]);
+  assert.equal(msg.type, 'NODE_CREATED');
+  assert.equal(msg.payload.text, 'hello');
+});


### PR DESCRIPTION
## Summary
- implement CreateNodeHandler to create nodes and broadcast
- track room info on sockets for broadcasting
- register handler in registry
- extend payload types with CreateNodePayload
- add unit tests for CreateNodeHandler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866a37b8ccc8332b920d30dd40e4bca