### PR TITLE
Add Join and Leave handler tests

### DIFF
--- a/backend/test/handlers/joinHandler.test.ts
+++ b/backend/test/handlers/joinHandler.test.ts
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { JoinHandler } from '../../src/handlers/JoinHandler.js';
+import StateManagerService from '../../src/services/StateManagerService.js';
+import { WebSocket } from 'ws';
+
+class MockSocket {
+  messages: string[] = [];
+  readyState = WebSocket.OPEN;
+  roomId?: string;
+  userId?: string;
+  send(data: string) {
+    this.messages.push(data);
+  }
+}
+
+test('JoinHandler adds user to room and responds with success', () => {
+  const stateManager = new StateManagerService();
+  const handler = new JoinHandler(stateManager);
+  const socket = new MockSocket();
+
+  handler.handle(socket as unknown as WebSocket, {
+    roomId: 'room1',
+    userId: 'user1',
+    userName: 'Alice',
+  } as any);
+
+  const room = stateManager.getRoom('room1');
+  assert.ok(room);
+  assert.ok(room!.users.has('user1'));
+  assert.equal((socket as any).roomId, 'room1');
+  assert.equal((socket as any).userId, 'user1');
+
+  assert.equal(socket.messages.length, 1);
+  const msg = JSON.parse(socket.messages[0]);
+  assert.equal(msg.success, true);
+});
+
+test('JoinHandler returns error on missing params', () => {
+  const stateManager = new StateManagerService();
+  const handler = new JoinHandler(stateManager);
+  const socket = new MockSocket();
+
+  handler.handle(socket as unknown as WebSocket, {
+    roomId: '',
+    userId: '',
+    userName: '',
+  } as any);
+
+  assert.equal(socket.messages.length, 1);
+  const msg = JSON.parse(socket.messages[0]);
+  assert.equal(msg.error, 'Room ID and User ID are required');
+  assert.equal(stateManager.getRoom(''), undefined);
+});

--- a/backend/test/handlers/leaveHandler.test.ts
+++ b/backend/test/handlers/leaveHandler.test.ts
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { LeaveHandler } from '../../src/handlers/LeaveHandler.js';
+import StateManagerService from '../../src/services/StateManagerService.js';
+import { WebSocket } from 'ws';
+
+class MockSocket {
+  messages: string[] = [];
+  readyState = WebSocket.OPEN;
+  send(data: string) {
+    this.messages.push(data);
+  }
+}
+
+test('LeaveHandler removes user and cleans up empty room', () => {
+  const stateManager = new StateManagerService();
+  stateManager.joinRoom('room1', 'user1', 'Alice');
+
+  const handler = new LeaveHandler(stateManager);
+  const socket = new MockSocket();
+
+  handler.handle(socket as unknown as WebSocket, {
+    roomId: 'room1',
+    userId: 'user1',
+  } as any);
+
+  const room = stateManager.getRoom('room1');
+  assert.equal(room, undefined);
+
+  assert.equal(socket.messages.length, 1);
+  const msg = JSON.parse(socket.messages[0]);
+  assert.deepStrictEqual(msg, {});
+});
+
+test('LeaveHandler returns error on missing params', () => {
+  const stateManager = new StateManagerService();
+  stateManager.joinRoom('room1', 'user1', 'Alice');
+
+  const handler = new LeaveHandler(stateManager);
+  const socket = new MockSocket();
+
+  handler.handle(socket as unknown as WebSocket, {
+    roomId: '',
+    userId: 'user1',
+  } as any);
+
+  assert.equal(socket.messages.length, 1);
+  const msg = JSON.parse(socket.messages[0]);
+  assert.equal(msg.error, 'User ID and Room ID are required');
+
+  const room = stateManager.getRoom('room1');
+  assert.ok(room);
+  assert.ok(room!.users.has('user1'));
+});


### PR DESCRIPTION
## Summary
- add test coverage for JoinHandler
- add test coverage for LeaveHandler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cd3bbdd9083328d9d9fa8b5c3a5ff